### PR TITLE
Add support for weights in both explicit and implicit models

### DIFF
--- a/spotlight/factorization/explicit.py
+++ b/spotlight/factorization/explicit.py
@@ -230,7 +230,7 @@ class ExplicitFactorizationModel(object):
 
                 self._optimizer.zero_grad()
 
-                loss = self._loss_func(minibatch.ratings, predictions, minibatch.weights)
+                loss = self._loss_func(minibatch.ratings, predictions, weights=minibatch.weights)
                 epoch_loss += loss.data[0]
 
                 loss.backward()

--- a/spotlight/factorization/explicit.py
+++ b/spotlight/factorization/explicit.py
@@ -9,13 +9,17 @@ import torch
 import torch.optim as optim
 
 from spotlight.helpers import _repr_model
+
 from spotlight.factorization._components import (_predict_process_features,
                                                  _predict_process_ids)
 from spotlight.factorization.representations import (BilinearNet,
                                                      FeatureNet,
                                                      HybridContainer)
-from spotlight.losses import (regression_loss,
-                              poisson_loss)
+from spotlight.losses import (
+    poisson_loss,
+    regression_loss
+)
+
 from spotlight.torch_utils import cpu, gpu, set_seed
 
 
@@ -226,7 +230,7 @@ class ExplicitFactorizationModel(object):
 
                 self._optimizer.zero_grad()
 
-                loss = self._loss_func(minibatch.ratings, predictions)
+                loss = self._loss_func(minibatch.ratings, predictions, minibatch.weights)
                 epoch_loss += loss.data[0]
 
                 loss.backward()

--- a/spotlight/factorization/implicit.py
+++ b/spotlight/factorization/implicit.py
@@ -17,6 +17,7 @@ from spotlight.losses import (adaptive_hinge_loss,
                               bpr_loss,
                               hinge_loss,
                               pointwise_loss)
+
 from spotlight.factorization.representations import (BilinearNet,
                                                      FeatureNet,
                                                      HybridContainer)
@@ -248,7 +249,8 @@ class ImplicitFactorizationModel(object):
                 loss = self._loss_func(
                     positive_prediction,
                     negative_prediction,
-                    weights=minibatch.weights)
+                    weights=minibatch.weights
+                )
 
                 epoch_loss += loss.data[0]
 

--- a/spotlight/factorization/implicit.py
+++ b/spotlight/factorization/implicit.py
@@ -245,7 +245,11 @@ class ImplicitFactorizationModel(object):
 
                 self._optimizer.zero_grad()
 
-                loss = self._loss_func(positive_prediction, negative_prediction)
+                loss = self._loss_func(
+                    positive_prediction,
+                    negative_prediction,
+                    weights=minibatch.weights)
+
                 epoch_loss += loss.data[0]
 
                 loss.backward()

--- a/spotlight/interactions.py
+++ b/spotlight/interactions.py
@@ -133,9 +133,9 @@ class Interactions(object):
     Attributes
     ----------
 
-    user_ids: array of np.int32
+    user_ids: array of np.int64
         array of user ids of the user-item pairs
-    item_ids: array of np.int32
+    item_ids: array of np.int64
         array of item ids of the user-item pairs
     ratings: array of np.float32, optional
         array of ratings
@@ -167,7 +167,6 @@ class Interactions(object):
         self.ratings = _float_or_none(ratings)
         self.timestamps = timestamps
         self.weights = _float_or_none(weights)
-
         self.user_features = _float_or_none(user_features)
         self.item_features = _float_or_none(item_features)
         self.context_features = _float_or_none(context_features)
@@ -237,7 +236,7 @@ class Interactions(object):
         self.item_ids = self.item_ids[indices]
         self.ratings = _slice_or_none(self.ratings, indices)
         self.timestamps = _slice_or_none(self.timestamps, indices)
-        self.weights = _slice_or_none(self.timestamps, indices)
+        self.weights = _slice_or_none(self.weights, indices)
         self.context_features = _slice_or_none(self.context_features, indices)
 
     def shuffle(self, random_state=None):

--- a/spotlight/losses.py
+++ b/spotlight/losses.py
@@ -242,7 +242,7 @@ def poisson_loss(observed_ratings, predicted_ratings, weights=None):
 
     assert_no_grad(observed_ratings)
 
-    loss = (predicted_ratings - observed_ratings) * torch.log(predicted_ratings)
+    loss = predicted_ratings - observed_ratings * torch.log(predicted_ratings)
 
     if weights is not None:
         loss = loss * weights

--- a/tests/factorization/test_explicit.py
+++ b/tests/factorization/test_explicit.py
@@ -6,51 +6,25 @@ import pytest
 from spotlight.cross_validation import random_train_test_split
 from spotlight.datasets import movielens
 from spotlight.evaluation import rmse_score
-from spotlight.losses import regression_loss, poisson_loss
 from spotlight.factorization.explicit import ExplicitFactorizationModel
 
-import torch
-from torch.autograd import Variable
 
 RANDOM_STATE = np.random.RandomState(42)
 CUDA = bool(os.environ.get('SPOTLIGHT_CUDA', False))
 
 
-def test_regression_loss():
-
-    # Test loss function with zero weights
-    observed_ratings = Variable(torch.from_numpy((2 * np.ones(100))))
-    predicted_ratings = Variable(torch.from_numpy((np.ones(100))))
-    weights = Variable(torch.from_numpy(np.zeros(100)))
-
-    out = regression_loss(observed_ratings, predicted_ratings, weights)
-    assert out.data.numpy().sum().item() == 0
-
-
-def test_poisson_loss():
-
-    # Test loss function with zero weights
-    observed_ratings = Variable(torch.from_numpy((2 * np.ones(100))))
-    predicted_ratings = Variable(torch.from_numpy((np.ones(100))))
-    weights = Variable(torch.from_numpy(np.zeros(100)))
-
-    out = poisson_loss(observed_ratings, predicted_ratings, weights)
-
-    assert out.data.numpy().sum().item() == 0
-
-
 @pytest.mark.parametrize('weight_factor, loss, expected', [
-    (1, 'regression', 0.5),
+    (1, 'regression', 1.0),
     (0, 'regression', 1.0),
     (1, 'poisson', 1.0),
-    (0, 'poisson', 2.0)
+    (0, 'poisson', 1.0)
 ])
 def test_model_fitting(weight_factor, loss, expected):
 
     interactions = movielens.get_movielens_dataset('100K')
 
     # Add weights
-    interactions.weights = weight_factor * np.ones((100000,))
+    interactions.weights = np.repeat(weight_factor, len(interactions))
 
     train, test = random_train_test_split(interactions,
                                           random_state=RANDOM_STATE)
@@ -59,14 +33,19 @@ def test_model_fitting(weight_factor, loss, expected):
                                        n_iter=10,
                                        batch_size=1024,
                                        learning_rate=1e-3,
-                                       l2=1e-5,
+                                       l2=1e-6,
                                        use_cuda=CUDA)
 
     model.fit(train)
 
     rmse = rmse_score(model, test)
 
-    assert rmse > expected
+    if weight_factor == 0:
+        # Check the RMSE is bad with zero weights...
+        assert rmse > expected
+    else:
+        # But good with normal weights.
+        assert rmse < expected
 
 
 def test_check_input():

--- a/tests/factorization/test_explicit.py
+++ b/tests/factorization/test_explicit.py
@@ -6,51 +6,67 @@ import pytest
 from spotlight.cross_validation import random_train_test_split
 from spotlight.datasets import movielens
 from spotlight.evaluation import rmse_score
+from spotlight.losses import regression_loss, poisson_loss
 from spotlight.factorization.explicit import ExplicitFactorizationModel
 
+import torch
+from torch.autograd import Variable
 
 RANDOM_STATE = np.random.RandomState(42)
 CUDA = bool(os.environ.get('SPOTLIGHT_CUDA', False))
 
 
-def test_regression():
+def test_regression_loss():
+
+    # Test loss function with zero weights
+    observed_ratings = Variable(torch.from_numpy((2 * np.ones(100))))
+    predicted_ratings = Variable(torch.from_numpy((np.ones(100))))
+    weights = Variable(torch.from_numpy(np.zeros(100)))
+
+    out = regression_loss(observed_ratings, predicted_ratings, weights)
+    assert out.data.numpy().sum().item() == 0
+
+
+def test_poisson_loss():
+
+    # Test loss function with zero weights
+    observed_ratings = Variable(torch.from_numpy((2 * np.ones(100))))
+    predicted_ratings = Variable(torch.from_numpy((np.ones(100))))
+    weights = Variable(torch.from_numpy(np.zeros(100)))
+
+    out = poisson_loss(observed_ratings, predicted_ratings, weights)
+
+    assert out.data.numpy().sum().item() == 0
+
+
+@pytest.mark.parametrize('weight_factor, loss, expected', [
+    (1, 'regression', 0.5),
+    (0, 'regression', 1.0),
+    (1, 'poisson', 1.0),
+    (0, 'poisson', 2.0)
+])
+def test_model_fitting(weight_factor, loss, expected):
 
     interactions = movielens.get_movielens_dataset('100K')
+
+    # Add weights
+    interactions.weights = weight_factor * np.ones((100000,))
 
     train, test = random_train_test_split(interactions,
                                           random_state=RANDOM_STATE)
 
-    model = ExplicitFactorizationModel(loss='regression',
+    model = ExplicitFactorizationModel(loss=loss,
                                        n_iter=10,
                                        batch_size=1024,
                                        learning_rate=1e-3,
                                        l2=1e-5,
                                        use_cuda=CUDA)
+
     model.fit(train)
 
     rmse = rmse_score(model, test)
 
-    assert rmse < 1.0
-
-
-def test_poisson():
-
-    interactions = movielens.get_movielens_dataset('100K')
-
-    train, test = random_train_test_split(interactions,
-                                          random_state=RANDOM_STATE)
-
-    model = ExplicitFactorizationModel(loss='poisson',
-                                       n_iter=10,
-                                       batch_size=1024,
-                                       learning_rate=1e-3,
-                                       l2=1e-6,
-                                       use_cuda=CUDA)
-    model.fit(train)
-
-    rmse = rmse_score(model, test)
-
-    assert rmse < 1.0
+    assert rmse > expected
 
 
 def test_check_input():

--- a/tests/factorization/test_implicit.py
+++ b/tests/factorization/test_implicit.py
@@ -4,19 +4,12 @@ import numpy as np
 
 import torch
 
-from torch.autograd import Variable
-
 import pytest
 
 from spotlight.cross_validation import random_train_test_split
 from spotlight.datasets import movielens, synthetic
 from spotlight.evaluation import mrr_score
-from spotlight.losses import (
-    adaptive_hinge_loss,
-    bpr_loss,
-    hinge_loss,
-    pointwise_loss
-)
+
 
 from spotlight.factorization.implicit import ImplicitFactorizationModel
 
@@ -53,7 +46,7 @@ def test_weights(weight_factor, loss, expected):
 
     # Add weights
     if weight_factor is not None:
-        interactions.weights = weight_factor * np.ones((100000,))
+        interactions.weights = np.repeat(weight_factor, len(interactions))
 
     train, test = random_train_test_split(interactions,
                                           random_state=RANDOM_STATE)
@@ -72,28 +65,6 @@ def test_weights(weight_factor, loss, expected):
         assert mrr < expected
     else:
         assert mrr > expected
-
-
-def test_pointwise_loss():
-
-    # Test loss function with zero weights
-    positive_predictions = Variable(torch.from_numpy((np.ones(100))))
-    negative_predictions = Variable(torch.from_numpy((np.ones(100))))
-    weights = Variable(torch.from_numpy(np.zeros(100)))
-
-    out = pointwise_loss(positive_predictions, negative_predictions, weights)
-    assert out.data.numpy().sum() == 0
-
-
-def test_bpr_loss():
-
-    # Test loss function with zero weights
-    positive_predictions = Variable(torch.from_numpy((np.ones(100))))
-    negative_predictions = Variable(torch.from_numpy((np.ones(100))))
-    weights = Variable(torch.from_numpy(np.zeros(100)))
-
-    out = bpr_loss(positive_predictions, negative_predictions, weights)
-    assert out.data.numpy().sum() == 0
 
 
 def test_bpr_custom_optimizer():
@@ -152,28 +123,6 @@ def test_bpr_hybrid(use_timestamps, expected_mrr):
     print('MRR {}'.format(mrr))
 
     assert mrr > expected_mrr
-
-
-def test_hinge_loss():
-
-    # Test loss function with zero weights
-    positive_predictions = Variable(torch.from_numpy((np.ones(100))))
-    negative_predictions = Variable(torch.from_numpy((np.ones(100))))
-    weights = Variable(torch.from_numpy(np.zeros(100)))
-
-    out = hinge_loss(positive_predictions, negative_predictions, weights)
-    assert out.data.numpy().sum() == 0
-
-
-def test_adaptive_hinge_loss():
-
-    # Test loss function with zero weights
-    positive_predictions = Variable(torch.from_numpy(np.random.random((1, 100))))
-    negative_predictions = Variable(torch.from_numpy(np.random.random((1, 100))))
-    weights = Variable(torch.from_numpy(np.zeros(100)))
-
-    out = adaptive_hinge_loss(positive_predictions, negative_predictions, weights)
-    assert out.data.numpy().sum() == 0
 
 
 @pytest.mark.parametrize('use_features, expected_mrr', [

--- a/tests/factorization/test_implicit.py
+++ b/tests/factorization/test_implicit.py
@@ -23,6 +23,39 @@ def _min_max_scale(arr):
     return (arr - arr_min) / (arr_max - arr_min)
 
 
+@pytest.mark.parametrize('weights, loss, expected', [
+    (np.ones((100000,)),'pointwise' , 0.05),
+    (np.zeros((100000,)),'pointwise' , 0.003),
+    (np.ones((100000,)),'bpr' , 0.05),
+    (np.zeros((100000,)),'bpr' , 0.003),
+    (np.ones((100000,)),'hinge' , 0.05),
+    (np.zeros((100000,)),'hinge' , 0.003),
+    (np.ones((100000,)),'adaptive_hinge' , 0.05),
+    (np.zeros((100000,)),'adaptive_hinge' , 0.003),
+])
+def test_weights(weights, loss, expected):
+
+    interactions = movielens.get_movielens_dataset('100K')
+
+    # Generate weights
+    interactions.weights = weights
+
+    train, test = random_train_test_split(interactions,
+                                          random_state=RANDOM_STATE)
+
+    model = ImplicitFactorizationModel(loss=loss,
+                                       n_iter=10,
+                                       batch_size=1024,
+                                       learning_rate=1e-2,
+                                       l2=1e-6,
+                                       use_cuda=CUDA)
+    model.fit(train)
+
+    mrr = mrr_score(model, test, train=train).mean()
+
+    assert mrr > expected
+
+
 def test_pointwise():
 
     interactions = movielens.get_movielens_dataset('100K')


### PR DESCRIPTION
This PR adds weight support to explicit and implicit models, by modifying the losses and the fit methods in the corresponding class.

TODO: Sample dataset for test.