### PR TITLE
Map metric

### DIFF
--- a/spotlight/evaluation.py
+++ b/spotlight/evaluation.py
@@ -95,7 +95,7 @@ def map_score(model, test, train=None):
             predictions[train[user_id].indices] = FLOAT_MAX
 
         prec = []
-        ranking = st.rankdata(predictions)[row.indices]
+        ranking = np.sort(st.rankdata(predictions)[row.indices])
         for index, value in enumerate(ranking):
             prec.append((index + 1) / value)
         ap.append(sum(prec) / len(ranking))


### PR DESCRIPTION
From #58

Wanted to add the MAP metric to the evaluation.py script.

Same interface as mrr_score. If the training dataset is provided, scores of known interactions are set to very low values to discard them.

Next step: Tweak it to calculate MAP@K