### PR TITLE
Fix dataset download paths on Windows

### DIFF
--- a/spotlight/datasets/amazon.py
+++ b/spotlight/datasets/amazon.py
@@ -16,12 +16,12 @@ def _download_amazon():
 
     extension = '.hdf5'
     url = ('https://github.com/maciejkula/recommender_datasets/'
-           'releases/download/')
+           'releases/download')
     version = '0.1.0'
 
-    path = _transport.get_data(os.path.join(url,
-                                            version,
-                                            'amazon_co_purchasing' + extension),
+    path = _transport.get_data('/'.join((url,
+                                         version,
+                                         'amazon_co_purchasing' + extension)),
                                'amazon',
                                'amazon_co_purchasing{}'.format(extension))
 

--- a/spotlight/datasets/amazon.py
+++ b/spotlight/datasets/amazon.py
@@ -2,8 +2,6 @@
 Utilities for fetching Amazon datasets
 """
 
-import os
-
 import h5py
 
 import numpy as np

--- a/spotlight/datasets/movielens.py
+++ b/spotlight/datasets/movielens.py
@@ -21,7 +21,7 @@ VARIANTS = ('100K',
 
 
 URL_PREFIX = ('https://github.com/maciejkula/recommender_datasets/'
-              'releases/download/')
+              'releases/download')
 VERSION = 'v0.2.0'
 
 
@@ -29,9 +29,9 @@ def _get_movielens(dataset):
 
     extension = '.hdf5'
 
-    path = _transport.get_data(os.path.join(URL_PREFIX,
-                                            VERSION,
-                                            dataset + extension),
+    path = _transport.get_data('/'.join((URL_PREFIX,
+                                         VERSION,
+                                         dataset + extension)),
                                os.path.join('movielens', VERSION),
                                'movielens_{}{}'.format(dataset,
                                                        extension))


### PR DESCRIPTION
Somewhat related to #82 

When running the examples on Windows 10, the download of the Movielens and Amazon datasets would fail with the error below,
```
spotlight\datasets\movielens.py in get_movielens_dataset(variant)
     68     url = 'movielens_{}'.format(variant)
     69 
---> 70     return Interactions(*_get_movielens(url))

HTTPError: 404 Client Error: Not Found for url: https://github.com/maciejkula/recommender_datasets/releases/download/v0.2.0%5Cmovielens_100K.hdf5
```

which is due to the fact that `os.path.join` is used to conctatenate the URL path which will produce backslashes on Windows. This replaces it with `"/".join` to be cross-platform. 