### PR TITLE
Implicit sequence weights and Implicit factorization weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# spotlight results files
+*_results.txt
+
 *~
 *#*
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 
 # IDE
 tags
+cscope.out

--- a/spotlight/factorization/implicit.py
+++ b/spotlight/factorization/implicit.py
@@ -225,13 +225,13 @@ class ImplicitFactorizationModel(object):
                         batch_user,
                         batch_item,
                     )
-                ) in enumerate(
-                    minibatch(
-                        user_ids_tensor,
-                        item_ids_tensor,
-                        batch_size=self._batch_size
-                    )
-                ):
+            ) in enumerate(
+                minibatch(
+                    user_ids_tensor,
+                    item_ids_tensor,
+                    batch_size=self._batch_size
+                )
+            ):
 
                 positive_prediction = self._net(batch_user, batch_item)
 
@@ -244,9 +244,9 @@ class ImplicitFactorizationModel(object):
                 self._optimizer.zero_grad()
 
                 loss = self._loss_func(
-                        positive_prediction,
-                        negative_prediction,
-                    )
+                    positive_prediction,
+                    negative_prediction,
+                )
                 epoch_loss += loss.item()
 
                 loss.backward()
@@ -294,17 +294,21 @@ class ImplicitFactorizationModel(object):
 
         for epoch_num in range(self._n_iter):
 
-            users, items, sample_weights = shuffle(user_ids,
-                                   item_ids,
-                                   sample_weights,
-                                   random_state=self._random_state)
+            users, items, sample_weights = shuffle(
+                user_ids,
+                item_ids,
+                sample_weights,
+                random_state=self._random_state
+            )
 
             user_ids_tensor = gpu(torch.from_numpy(users),
                                   self._use_cuda)
             item_ids_tensor = gpu(torch.from_numpy(items),
                                   self._use_cuda)
-            sample_weights_tensor = gpu(torch.from_numpy(sample_weights),
-                                  self._use_cuda)
+            sample_weights_tensor = gpu(
+                torch.from_numpy(sample_weights),
+                self._use_cuda
+            )
 
             epoch_loss = 0.0
 
@@ -315,14 +319,14 @@ class ImplicitFactorizationModel(object):
                         batch_item,
                         batch_sample_weights
                     )
-                ) in enumerate(
-                    minibatch(
-                        user_ids_tensor,
-                        item_ids_tensor,
-                        sample_weights_tensor,
-                        batch_size=self._batch_size
-                    )
-                ):
+            ) in enumerate(
+                minibatch(
+                    user_ids_tensor,
+                    item_ids_tensor,
+                    sample_weights_tensor,
+                    batch_size=self._batch_size
+                )
+            ):
 
                 positive_prediction = self._net(batch_user, batch_item)
 
@@ -335,9 +339,10 @@ class ImplicitFactorizationModel(object):
                 self._optimizer.zero_grad()
 
                 loss = self._loss_func(
-                        positive_prediction,
-                        negative_prediction,
-                        sample_weights=batch_sample_weights)
+                    positive_prediction,
+                    negative_prediction,
+                    sample_weights=batch_sample_weights
+                )
                 epoch_loss += loss.item()
 
                 loss.backward()

--- a/spotlight/factorization/implicit.py
+++ b/spotlight/factorization/implicit.py
@@ -198,7 +198,6 @@ class ImplicitFactorizationModel(object):
         verbose: bool
             Output additional information about current epoch and loss.
         """
-
         user_ids = interactions.user_ids.astype(np.int64)
         item_ids = interactions.item_ids.astype(np.int64)
 
@@ -220,11 +219,19 @@ class ImplicitFactorizationModel(object):
 
             epoch_loss = 0.0
 
-            for (minibatch_num,
-                 (batch_user,
-                  batch_item)) in enumerate(minibatch(user_ids_tensor,
-                                                      item_ids_tensor,
-                                                      batch_size=self._batch_size)):
+            for (
+                    minibatch_num,
+                    (
+                        batch_user,
+                        batch_item,
+                    )
+                ) in enumerate(
+                    minibatch(
+                        user_ids_tensor,
+                        item_ids_tensor,
+                        batch_size=self._batch_size
+                    )
+                ):
 
                 positive_prediction = self._net(batch_user, batch_item)
 
@@ -236,7 +243,101 @@ class ImplicitFactorizationModel(object):
 
                 self._optimizer.zero_grad()
 
-                loss = self._loss_func(positive_prediction, negative_prediction)
+                loss = self._loss_func(
+                        positive_prediction,
+                        negative_prediction,
+                    )
+                epoch_loss += loss.item()
+
+                loss.backward()
+                self._optimizer.step()
+
+            epoch_loss /= minibatch_num + 1
+
+            if verbose:
+                print('Epoch {}: loss {}'.format(epoch_num, epoch_loss))
+
+            if np.isnan(epoch_loss) or epoch_loss == 0.0:
+                raise ValueError('Degenerate epoch loss: {}'
+                                 .format(epoch_loss))
+
+    def fit_weighted(self, interactions, verbose=False):
+        """
+        Fit the model using sample weights.
+
+        When called repeatedly, model fitting will resume from
+        the point at which training stopped in the previous fit
+        call.
+
+        Parameters
+        ----------
+
+        interactions: :class:`spotlight.interactions.Interactions`
+            The input dataset.
+
+        verbose: bool
+            Output additional information about current epoch and loss.
+        """
+        if interactions.weights is None:
+            raise ValueError('''Sample weights must be specified in the
+            interactions object. If you don't have sample weights,
+            use the fit method instead''')
+
+        user_ids = interactions.user_ids.astype(np.int64)
+        item_ids = interactions.item_ids.astype(np.int64)
+        sample_weights = interactions.weights.astype(np.float32)
+
+        if not self._initialized:
+            self._initialize(interactions)
+
+        self._check_input(user_ids, item_ids)
+
+        for epoch_num in range(self._n_iter):
+
+            users, items, sample_weights = shuffle(user_ids,
+                                   item_ids,
+                                   sample_weights,
+                                   random_state=self._random_state)
+
+            user_ids_tensor = gpu(torch.from_numpy(users),
+                                  self._use_cuda)
+            item_ids_tensor = gpu(torch.from_numpy(items),
+                                  self._use_cuda)
+            sample_weights_tensor = gpu(torch.from_numpy(sample_weights),
+                                  self._use_cuda)
+
+            epoch_loss = 0.0
+
+            for (
+                    minibatch_num,
+                    (
+                        batch_user,
+                        batch_item,
+                        batch_sample_weights
+                    )
+                ) in enumerate(
+                    minibatch(
+                        user_ids_tensor,
+                        item_ids_tensor,
+                        sample_weights_tensor,
+                        batch_size=self._batch_size
+                    )
+                ):
+
+                positive_prediction = self._net(batch_user, batch_item)
+
+                if self._loss == 'adaptive_hinge':
+                    negative_prediction = self._get_multiple_negative_predictions(
+                        batch_user, n=self._num_negative_samples)
+                else:
+                    negative_prediction = self._get_negative_prediction(batch_user)
+
+                self._optimizer.zero_grad()
+
+                loss = self._loss_func(
+                        positive_prediction,
+                        negative_prediction,
+                        sample_weights=batch_sample_weights)
                 epoch_loss += loss.item()
 
                 loss.backward()

--- a/spotlight/factorization/implicit.py
+++ b/spotlight/factorization/implicit.py
@@ -198,6 +198,10 @@ class ImplicitFactorizationModel(object):
         verbose: bool
             Output additional information about current epoch and loss.
         """
+        # Call weighted fit method if sample weights are specified
+        if interactions.weights is not None:
+            return _fit_weighted(self, interactions, verbose=False)
+
         user_ids = interactions.user_ids.astype(np.int64)
         item_ids = interactions.item_ids.astype(np.int64)
 
@@ -261,7 +265,7 @@ class ImplicitFactorizationModel(object):
                 raise ValueError('Degenerate epoch loss: {}'
                                  .format(epoch_loss))
 
-    def fit_weighted(self, interactions, verbose=False):
+    def _fit_weighted(self, interactions, verbose=False):
         """
         Fit the model using sample weights.
 

--- a/spotlight/interactions.py
+++ b/spotlight/interactions.py
@@ -310,7 +310,7 @@ class Interactions(object):
 
         for i, (uid,
                 seq) in enumerate(_generate_sequences(user_ids,
-                                                      weight_sequences,
+                                                      weights,
                                                       indices,
                                                       max_sequence_length,
                                                       step_size)):

--- a/spotlight/interactions.py
+++ b/spotlight/interactions.py
@@ -14,7 +14,7 @@ def _sliding_window(tensor, window_size, step_size=1):
         yield tensor[max(i - window_size, 0):i]
 
 
-def _generate_sequences(user_ids, item_ids,
+def _generate_sequences(user_ids, sequence_elements,
                         indices,
                         max_sequence_length,
                         step_size):
@@ -28,7 +28,7 @@ def _generate_sequences(user_ids, item_ids,
         else:
             stop_idx = indices[i + 1]
 
-        for seq in _sliding_window(item_ids[start_idx:stop_idx],
+        for seq in _sliding_window(sequence_elements[start_idx:stop_idx],
                                    max_sequence_length,
                                    step_size):
 
@@ -266,56 +266,7 @@ class Interactions(object):
                                      num_items=self.num_items))
 
     def to_sequence_weighted(self, max_sequence_length=10, min_sequence_length=None, step_size=None):
-        """
-        Transform to sequence form.
-
-        User-item interaction pairs are sorted by their timestamps,
-        and sequences of up to max_sequence_length events are arranged
-        into a (zero-padded from the left) matrix with dimensions
-        (num_sequences x max_sequence_length).
-
-        Valid subsequences of users' interactions are returned. For
-        example, if a user interacted with items [1, 2, 3, 4, 5], the
-        returned interactions matrix at sequence length 5 and step size
-        1 will be be given by:
-
-        .. code-block:: python
-
-           [[1, 2, 3, 4, 5],
-            [0, 1, 2, 3, 4],
-            [0, 0, 1, 2, 3],
-            [0, 0, 0, 1, 2],
-            [0, 0, 0, 0, 1]]
-
-        At step size 2:
-
-        .. code-block:: python
-
-           [[1, 2, 3, 4, 5],
-            [0, 0, 1, 2, 3],
-            [0, 0, 0, 0, 1]]
-
-        Parameters
-        ----------
-
-        max_sequence_length: int, optional
-            Maximum sequence length. Subsequences shorter than this
-            will be left-padded with zeros.
-        min_sequence_length: int, optional
-            If set, only sequences with at least min_sequence_length
-            non-padding elements will be returned.
-        step-size: int, optional
-            The returned subsequences are the effect of moving a
-            a sliding window over the input. This parameter
-            governs the stride of that window. Increasing it will
-            result in fewer subsequences being returned.
-
-        Returns
-        -------
-
-        sequence interactions: :class:`~SequenceInteractions`
-            The resulting sequence interactions.
-        """
+        """Ref to_sequence"""
 
         if self.timestamps is None:
             raise ValueError('Cannot convert to sequences, '
@@ -344,6 +295,8 @@ class Interactions(object):
 
         sequences = np.zeros((num_subsequences, max_sequence_length),
                              dtype=np.int32)
+        weight_sequences = np.zeros((num_subsequences, max_sequence_length),
+                             dtype=np.int32)
         sequence_users = np.empty(num_subsequences,
                                   dtype=np.int32)
         for i, (uid,
@@ -355,13 +308,23 @@ class Interactions(object):
             sequences[i][-len(seq):] = seq
             sequence_users[i] = uid
 
+        for i, (uid,
+                seq) in enumerate(_generate_sequences(user_ids,
+                                                      weight_sequences,
+                                                      indices,
+                                                      max_sequence_length,
+                                                      step_size)):
+            weight_sequences[i][-len(seq):] = seq
+
         if min_sequence_length is not None:
             long_enough = sequences[:, -min_sequence_length] != 0
             sequences = sequences[long_enough]
+            weight_sequences = weight_sequences[long_enough]
             sequence_users = sequence_users[long_enough]
 
         return (SequenceInteractions(sequences,
                                      user_ids=sequence_users,
+                                     weight_sequences=weight_sequences,
                                      num_items=self.num_items))
 
 

--- a/spotlight/interactions.py
+++ b/spotlight/interactions.py
@@ -168,56 +168,56 @@ class Interactions(object):
         return self.tocoo().tocsr()
 
     def to_sequence(self, max_sequence_length=10, min_sequence_length=None, step_size=None):
-         """
-         Transform to sequence form.
- 
-         User-item interaction pairs are sorted by their timestamps,
-         and sequences of up to max_sequence_length events are arranged
-         into a (zero-padded from the left) matrix with dimensions
-         (num_sequences x max_sequence_length).
- 
-         Valid subsequences of users' interactions are returned. For
-         example, if a user interacted with items [1, 2, 3, 4, 5], the
-         returned interactions matrix at sequence length 5 and step size
-         1 will be be given by:
- 
-         .. code-block:: python
- 
-            [[1, 2, 3, 4, 5],
-             [0, 1, 2, 3, 4],
-             [0, 0, 1, 2, 3],
-             [0, 0, 0, 1, 2],
-             [0, 0, 0, 0, 1]]
- 
-         At step size 2:
- 
-         .. code-block:: python
- 
-            [[1, 2, 3, 4, 5],
-             [0, 0, 1, 2, 3],
-             [0, 0, 0, 0, 1]]
- 
-         Parameters
-         ----------
- 
-         max_sequence_length: int, optional
-             Maximum sequence length. Subsequences shorter than this
-             will be left-padded with zeros.
-         min_sequence_length: int, optional
-             If set, only sequences with at least min_sequence_length
-             non-padding elements will be returned.
-         step-size: int, optional
-             The returned subsequences are the effect of moving a
-             a sliding window over the input. This parameter
-             governs the stride of that window. Increasing it will
-             result in fewer subsequences being returned.
- 
-         Returns
-         -------
- 
-         sequence interactions: :class:`~SequenceInteractions`
-             The resulting sequence interactions.
-         """
+        """
+        Transform to sequence form.
+
+        User-item interaction pairs are sorted by their timestamps,
+        and sequences of up to max_sequence_length events are arranged
+        into a (zero-padded from the left) matrix with dimensions
+        (num_sequences x max_sequence_length).
+
+        Valid subsequences of users' interactions are returned. For
+        example, if a user interacted with items [1, 2, 3, 4, 5], the
+        returned interactions matrix at sequence length 5 and step size
+        1 will be be given by:
+
+        .. code-block:: python
+
+           [[1, 2, 3, 4, 5],
+            [0, 1, 2, 3, 4],
+            [0, 0, 1, 2, 3],
+            [0, 0, 0, 1, 2],
+            [0, 0, 0, 0, 1]]
+
+        At step size 2:
+
+        .. code-block:: python
+
+           [[1, 2, 3, 4, 5],
+            [0, 0, 1, 2, 3],
+            [0, 0, 0, 0, 1]]
+
+        Parameters
+        ----------
+
+        max_sequence_length: int, optional
+            Maximum sequence length. Subsequences shorter than this
+            will be left-padded with zeros.
+        min_sequence_length: int, optional
+            If set, only sequences with at least min_sequence_length
+            non-padding elements will be returned.
+        step-size: int, optional
+            The returned subsequences are the effect of moving a
+            a sliding window over the input. This parameter
+            governs the stride of that window. Increasing it will
+            result in fewer subsequences being returned.
+
+        Returns
+        -------
+
+        sequence interactions: :class:`~SequenceInteractions`
+            The resulting sequence interactions.
+        """
         weighted = self.weights is not None
         if self.timestamps is None:
             raise ValueError('Cannot convert to sequences, '
@@ -250,7 +250,7 @@ class Interactions(object):
         weight_sequences = None
         if weighted:
             weight_sequences = np.zeros((num_subsequences, max_sequence_length),
-                                 dtype=np.int32)
+                                        dtype=np.int32)
         sequence_users = np.empty(num_subsequences,
                                   dtype=np.int32)
         for i, (uid,

--- a/spotlight/interactions.py
+++ b/spotlight/interactions.py
@@ -63,7 +63,7 @@ class Interactions(object):
     timestamps: array of np.int32, optional
         array of timestamps
     weights: array of np.float32, optional
-        array of weights
+        array of sample importance weights
     num_users: int, optional
         Number of distinct users in the dataset.
         Must be larger than the maximum user id
@@ -85,7 +85,7 @@ class Interactions(object):
     timestamps: array of np.int32, optional
         array of timestamps
     weights: array of np.float32, optional
-        array of weights
+        array of sample importance weights
     num_users: int, optional
         Number of distinct users in the dataset.
     num_items: int, optional
@@ -265,6 +265,105 @@ class Interactions(object):
                                      user_ids=sequence_users,
                                      num_items=self.num_items))
 
+    def to_sequence_weighted(self, max_sequence_length=10, min_sequence_length=None, step_size=None):
+        """
+        Transform to sequence form.
+
+        User-item interaction pairs are sorted by their timestamps,
+        and sequences of up to max_sequence_length events are arranged
+        into a (zero-padded from the left) matrix with dimensions
+        (num_sequences x max_sequence_length).
+
+        Valid subsequences of users' interactions are returned. For
+        example, if a user interacted with items [1, 2, 3, 4, 5], the
+        returned interactions matrix at sequence length 5 and step size
+        1 will be be given by:
+
+        .. code-block:: python
+
+           [[1, 2, 3, 4, 5],
+            [0, 1, 2, 3, 4],
+            [0, 0, 1, 2, 3],
+            [0, 0, 0, 1, 2],
+            [0, 0, 0, 0, 1]]
+
+        At step size 2:
+
+        .. code-block:: python
+
+           [[1, 2, 3, 4, 5],
+            [0, 0, 1, 2, 3],
+            [0, 0, 0, 0, 1]]
+
+        Parameters
+        ----------
+
+        max_sequence_length: int, optional
+            Maximum sequence length. Subsequences shorter than this
+            will be left-padded with zeros.
+        min_sequence_length: int, optional
+            If set, only sequences with at least min_sequence_length
+            non-padding elements will be returned.
+        step-size: int, optional
+            The returned subsequences are the effect of moving a
+            a sliding window over the input. This parameter
+            governs the stride of that window. Increasing it will
+            result in fewer subsequences being returned.
+
+        Returns
+        -------
+
+        sequence interactions: :class:`~SequenceInteractions`
+            The resulting sequence interactions.
+        """
+
+        if self.timestamps is None:
+            raise ValueError('Cannot convert to sequences, '
+                             'timestamps not available.')
+
+        if 0 in self.item_ids:
+            raise ValueError('0 is used as an item id, conflicting '
+                             'with the sequence padding value.')
+
+        if step_size is None:
+            step_size = max_sequence_length
+
+        # Sort first by user id, then by timestamp
+        sort_indices = np.lexsort((self.timestamps,
+                                   self.user_ids))
+
+        user_ids = self.user_ids[sort_indices]
+        item_ids = self.item_ids[sort_indices]
+        weights = self.weights[sort_indices]
+
+        user_ids, indices, counts = np.unique(user_ids,
+                                              return_index=True,
+                                              return_counts=True)
+
+        num_subsequences = int(np.ceil(counts / float(step_size)).sum())
+
+        sequences = np.zeros((num_subsequences, max_sequence_length),
+                             dtype=np.int32)
+        sequence_users = np.empty(num_subsequences,
+                                  dtype=np.int32)
+        for i, (uid,
+                seq) in enumerate(_generate_sequences(user_ids,
+                                                      item_ids,
+                                                      indices,
+                                                      max_sequence_length,
+                                                      step_size)):
+            sequences[i][-len(seq):] = seq
+            sequence_users[i] = uid
+
+        if min_sequence_length is not None:
+            long_enough = sequences[:, -min_sequence_length] != 0
+            sequences = sequences[long_enough]
+            sequence_users = sequence_users[long_enough]
+
+        return (SequenceInteractions(sequences,
+                                     user_ids=sequence_users,
+                                     num_items=self.num_items))
+
 
 class SequenceInteractions(object):
     """
@@ -276,6 +375,11 @@ class SequenceInteractions(object):
     sequences: array of np.int32 of shape (num_sequences x max_sequence_length)
         The interactions sequence matrix, as produced by
         :func:`~Interactions.to_sequence`
+    user_ids: array of np.int32, optional
+        user_id represented by a sequence of item_ids.
+    weight_sequences: array of np.int32 of shape
+        (num_sequences x max_sequence_length), optional.
+        Sequence of sample weights.
     num_items: int, optional
         The number of distinct items in the data
 
@@ -287,11 +391,11 @@ class SequenceInteractions(object):
         :func:`~Interactions.to_sequence`
     """
 
-    def __init__(self,
-                 sequences,
-                 user_ids=None, num_items=None):
+    def __init__(self, sequences,
+                 user_ids=None, weight_sequences=None, num_items=None):
 
         self.sequences = sequences
+        self.weight_sequences = weight_sequences
         self.user_ids = user_ids
         self.max_sequence_length = sequences.shape[1]
 

--- a/spotlight/losses.py
+++ b/spotlight/losses.py
@@ -207,11 +207,11 @@ def adaptive_hinge_loss(
     highest_negative_predictions, _ = torch.max(negative_predictions, 0)
 
     return hinge_loss(
-            positive_predictions,
-            highest_negative_predictions.squeeze(),
-            sample_weights=sample_weights,
-            mask=mask
-        )
+        positive_predictions,
+        highest_negative_predictions.squeeze(),
+        sample_weights=sample_weights,
+        mask=mask
+    )
 
 
 def regression_loss(
@@ -318,14 +318,14 @@ def logistic_loss(
 
     if sample_weights is not None or mask is not None:
         loss = F.binary_cross_entropy_with_logits(
-                    predicted_ratings,
-                    observed_ratings,
-                    size_average=False
-                )
+            predicted_ratings,
+            observed_ratings,
+            size_average=False
+        )
         return base_loss(loss, sample_weights, mask)
 
     return F.binary_cross_entropy_with_logits(
-                    predicted_ratings,
-                    observed_ratings,
-                    size_average=True
-                )
+        predicted_ratings,
+        observed_ratings,
+        size_average=True
+    )

--- a/spotlight/losses.py
+++ b/spotlight/losses.py
@@ -123,7 +123,6 @@ def bpr_loss(
     return _weighted_loss(loss, sample_weights, mask)
 
 
-
 def hinge_loss(
         positive_predictions, negative_predictions,
         sample_weights=None, mask=None):

--- a/spotlight/sequence/implicit.py
+++ b/spotlight/sequence/implicit.py
@@ -206,79 +206,9 @@ class ImplicitSequenceModel(object):
         """
 
         sequences = interactions.sequences.astype(np.int64)
-
-        if not self._initialized:
-            self._initialize(interactions)
-
-        self._check_input(sequences)
-
-        for epoch_num in range(self._n_iter):
-
-            sequences = shuffle(sequences,
-                                random_state=self._random_state)
-
-            sequences_tensor = gpu(torch.from_numpy(sequences),
-                                   self._use_cuda)
-
-            epoch_loss = 0.0
-
-            for minibatch_num, batch_sequence in enumerate(minibatch(sequences_tensor,
-                                                                     batch_size=self._batch_size)):
-
-                sequence_var = batch_sequence
-
-                user_representation, _ = self._net.user_representation(
-                    sequence_var
-                )
-
-                positive_prediction = self._net(user_representation,
-                                                sequence_var)
-
-                if self._loss == 'adaptive_hinge':
-                    negative_prediction = self._get_multiple_negative_predictions(
-                        sequence_var.size(),
-                        user_representation,
-                        n=self._num_negative_samples)
-                else:
-                    negative_prediction = self._get_negative_prediction(sequence_var.size(),
-                                                                        user_representation)
-
-                self._optimizer.zero_grad()
-
-                loss = self._loss_func(positive_prediction,
-                                       negative_prediction,
-                                       mask=(sequence_var != PADDING_IDX))
-                epoch_loss += loss.item()
-
-                loss.backward()
-
-                self._optimizer.step()
-
-            epoch_loss /= minibatch_num + 1
-
-            if verbose:
-                print('Epoch {}: loss {}'.format(epoch_num, epoch_loss))
-
-            if np.isnan(epoch_loss) or epoch_loss == 0.0:
-                raise ValueError('Degenerate epoch loss: {}'
-                                 .format(epoch_loss))
-
-    def _fit_weighted(self, interactions, verbose=False):
-        """
-        Fit the model.
-
-        When called repeatedly, model fitting will resume from
-        the point at which training stopped in the previous fit
-        call.
-
-        Parameters
-        ----------
-
-        interactions: :class:`spotlight.interactions.SequenceInteractions`
-            The input sequence dataset.
-        """
-
-        sequences = interactions.sequences.astype(np.int64)
+        sample_weight_sequences = None
+        if interactions.weight_sequences is not None:
+            sample_weight_sequences = interactions.weight_sequences.astype(np.int64)
 
         if not self._initialized:
             self._initialize(interactions)
@@ -290,17 +220,21 @@ class ImplicitSequenceModel(object):
             sequences = shuffle(sequences, random_state=self._random_state)
 
             sequences_tensor = gpu(torch.from_numpy(sequences), self._use_cuda)
-            weight_sequences_tensor = gpu(
-                torch.from_numpy(weight_sequences),
-                self._use_cuda
-            )
+            weight_sequences_tensor = None
+            if sample_weight_sequences is not None:
+                weight_sequences_tensor = gpu(
+                    torch.from_numpy(sample_weight_sequences),
+                    self._use_cuda
+                )
 
             epoch_loss = 0.0
 
             for (
                     minibatch_num,
-                    batch_sequence,
-                    batch_weight_sequence
+                    (
+                        batch_sequence,
+                        batch_weight_sequence
+                    )
                 ) in enumerate(
                 minibatch(
                     sequences_tensor,
@@ -330,11 +264,15 @@ class ImplicitSequenceModel(object):
 
                 self._optimizer.zero_grad()
 
-                # TODO examine weight sequence's effect on mask logic
-                loss = self._loss_func(positive_prediction,
-                                       negative_prediction,
-                                       weight_sequence_var,
-                                       mask=(sequence_var != PADDING_IDX))
+                padding_mask = (sequence_var != PADDING_IDX)
+                padding_mask = padding_mask.type(torch.LongTensor)
+                masked_weights = weight_sequence_var * padding_mask
+                masked_weights = masked_weights.type(torch.FloatTensor)
+                loss = self._loss_func(
+                            positive_prediction,
+                            negative_prediction,
+                            sample_weights=masked_weights,
+                        )
                 epoch_loss += loss.item()
 
                 loss.backward()

--- a/spotlight/sequence/implicit.py
+++ b/spotlight/sequence/implicit.py
@@ -235,7 +235,7 @@ class ImplicitSequenceModel(object):
                         batch_sequence,
                         batch_weight_sequence
                     )
-                ) in enumerate(
+            ) in enumerate(
                 minibatch(
                     sequences_tensor,
                     weight_sequences_tensor,
@@ -269,10 +269,10 @@ class ImplicitSequenceModel(object):
                 masked_weights = weight_sequence_var * padding_mask
                 masked_weights = masked_weights.type(torch.FloatTensor)
                 loss = self._loss_func(
-                            positive_prediction,
-                            negative_prediction,
-                            sample_weights=masked_weights,
-                        )
+                    positive_prediction,
+                    negative_prediction,
+                    sample_weights=masked_weights,
+                )
                 epoch_loss += loss.item()
 
                 loss.backward()

--- a/spotlight/torch_utils.py
+++ b/spotlight/torch_utils.py
@@ -29,14 +29,14 @@ def minibatch(*tensors, **kwargs):
             yield tensor[i:i + batch_size]
     else:
         for i in range(0, len(tensors[0]), batch_size):
-            yield tuple(x[i:i + batch_size] for x in tensors)
+            yield tuple(x[i:i + batch_size] if x is not None else None for x in tensors)
 
 
 def shuffle(*arrays, **kwargs):
 
     random_state = kwargs.get('random_state')
 
-    if len(set(len(x) for x in arrays)) != 1:
+    if len(set(len(x) for x in arrays if x is not None)) != 1:
         raise ValueError('All inputs to shuffle must have '
                          'the same length.')
 
@@ -49,7 +49,7 @@ def shuffle(*arrays, **kwargs):
     if len(arrays) == 1:
         return arrays[0][shuffle_indices]
     else:
-        return tuple(x[shuffle_indices] for x in arrays)
+        return tuple(x[shuffle_indices] if x is not None else None for x in arrays)
 
 
 def assert_no_grad(variable):


### PR DESCRIPTION
This branches off of the sample-weights branch we have a pr going on with right now in order to leverage the new losses logic.

I combined the fit and fit_weighted functions for implicit factorizations, subsume mask_padding into sample_weights and create support for sample weights in to_sequence and implicit sequence.

If you're happy with these changes, you can just merge this branch into master and close out the sample-weights PR without merging.