### PR TITLE
Fixed the docstring for the ZeroEmbedding Layer

### DIFF
--- a/spotlight/layers.py
+++ b/spotlight/layers.py
@@ -40,8 +40,7 @@ class ScaledEmbedding(nn.Embedding):
 class ZeroEmbedding(nn.Embedding):
     """
     Embedding layer that initialises its values
-    to using a normal variable scaled by the inverse
-    of the embedding dimension.
+    to zero.
 
     Used for biases.
     """


### PR DESCRIPTION
I do not think the present docstring for the ZeroEmbedding makes sense because you are not scaling anything, its just initialized to zero.