### PR TITLE
docs: fix simple typo, imcompatible -> incompatible

### DIFF
--- a/tests/factorization/test_explicit.py
+++ b/tests/factorization/test_explicit.py
@@ -97,7 +97,7 @@ def test_check_input():
                                        use_cuda=CUDA)
     model.fit(train)
 
-    # Modify data to make imcompatible with original model.
+    # Modify data to make incompatible with original model.
     train.user_ids[0] = train.user_ids.max() + 1
     with pytest.raises(ValueError):
         model.fit(train)


### PR DESCRIPTION
There is a small typo in tests/factorization/test_explicit.py.

Should read `incompatible` rather than `imcompatible`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md